### PR TITLE
Reworked bank page to include tabs

### DIFF
--- a/lib/pages/bank/generic_bank.dart
+++ b/lib/pages/bank/generic_bank.dart
@@ -48,28 +48,9 @@ class GenericBankPage extends StatelessWidget {
                   await Future.delayed(Duration(milliseconds: 200), () {});
                 },
                 child: CompanionListView(
-                  children: <Widget>[
-                    Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Wrap(
-                        alignment: WrapAlignment.center,
-                        spacing: 4.0,
-                        runSpacing: 4.0,
-                        children: inventory
-                          .where((i) => i.id != -1)
-                          .map((i) => CompanionItemBox(
-                            item: i.itemInfo,
-                            skin: i.skinInfo,
-                            hero: '${inventory.indexOf(i)}${i.id}',
-                            upgradesInfo: i.upgradesInfo,
-                            infusionsInfo: i.infusionsInfo,
-                            quantity: i.charges != null ? i.charges : i.count,
-                            includeMargin: false,
-                          ))
-                          .toList(),
-                      ),
-                    ),
-                  ],
+                  children: bankType == BankType.bank
+                    ? _buildBank(context, inventory)
+                    : _buildSharedInventory(inventory),
                 ),
               );
             }
@@ -81,6 +62,88 @@ class GenericBankPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  List<Widget> _buildBank(BuildContext context, List<InventoryItem> inventory) {
+    return Iterable
+      .generate((inventory.length / 30).ceil())
+      .map((index) {
+        List<InventoryItem> bankTab = inventory
+          .skip(index * 30)
+          .take(30)
+          .toList();
+
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+          child: Column(
+            children: [
+              Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Text(
+                  "${bankTab.where((i) => i.id != -1).length} / ${bankTab.length} slots",
+                  style: Theme.of(context).textTheme.headline2,
+                ),
+              ),
+              Container(
+                width: double.infinity,
+                margin: EdgeInsets.only(top: 8.0),
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 4.0,
+                  runSpacing: 4.0,
+                  children: bankTab
+                    .map((i) {
+                      if (i.id == -1) {
+                        return CompanionItemBox(
+                          item: null,
+                          displayEmpty: true,
+                          includeMargin: false,
+                        );
+                      }
+
+                      return CompanionItemBox(
+                        item: i.itemInfo,
+                        skin: i.skinInfo,
+                        hero: '${inventory.indexOf(i)}${i.id}',
+                        upgradesInfo: i.upgradesInfo,
+                        infusionsInfo: i.infusionsInfo,
+                        quantity: i.charges != null ? i.charges : i.count,
+                        includeMargin: false,
+                      );
+                    })
+                    .toList(),
+                ),
+              ),
+            ],
+          ),
+        );
+      })
+      .toList();
+  }
+
+  List<Widget> _buildSharedInventory(List<InventoryItem> inventory) {
+    return <Widget>[
+      Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Wrap(
+          alignment: WrapAlignment.center,
+          spacing: 4.0,
+          runSpacing: 4.0,
+          children: inventory
+            .where((i) => i.id != -1)
+            .map((i) => CompanionItemBox(
+              item: i.itemInfo,
+              skin: i.skinInfo,
+              hero: '${inventory.indexOf(i)}${i.id}',
+              upgradesInfo: i.upgradesInfo,
+              infusionsInfo: i.infusionsInfo,
+              quantity: i.charges != null ? i.charges : i.count,
+              includeMargin: false,
+            ))
+            .toList(),
+        ),
+      ),
+    ];
   }
 }
 

--- a/lib/services/bank.dart
+++ b/lib/services/bank.dart
@@ -28,7 +28,7 @@ class BankService {
 
     if (response.statusCode == 200) {
       List items = response.data;
-      return items.where((a) => a != null).map((a) => InventoryItem.fromJson(a)).toList();
+      return items.map((a) => InventoryItem.fromJson(a)).toList();
     }
 
     throw Exception();


### PR DESCRIPTION
Reworked the bank page to include tabs.

## Description

- Empty item slots are now displayed.
- Spacing is added between every 30 item slots to indicate different bank tabs.
- Above each bank tab the amount of items is listed.

## Related Issue
Closes #45 

## Screenshots (if appropriate):
![Screenshot bank tabs](https://user-images.githubusercontent.com/22204349/91636103-52e62180-e9fe-11ea-8848-79dbe3388514.png)
