### PR TITLE
Searchable materials

### DIFF
--- a/lib/features/bank/pages/material.dart
+++ b/lib/features/bank/pages/material.dart
@@ -97,6 +97,21 @@ class _MaterialCategoryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var items = category.materials
+      .where((i) => i.itemInfo.name.toLowerCase().contains(search.toLowerCase()))
+      .map((i) => ItemBox(
+        item: i.itemInfo,
+        quantity: i.count,
+        hero: '${i.id} ${category.materials.indexOf(i)}',
+        includeMargin: false,
+        section: ItemSection.MATERIAL,
+      ))
+      .toList();
+
+    if (items.isEmpty) {
+      return Container();
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       child: Column(
@@ -115,16 +130,7 @@ class _MaterialCategoryCard extends StatelessWidget {
               alignment: WrapAlignment.center,
               spacing: 4.0,
               runSpacing: 4.0,
-              children: category.materials
-                .where((i) => i.itemInfo.name.toLowerCase().contains(search.toLowerCase()))
-                .map((i) => ItemBox(
-                  item: i.itemInfo,
-                  quantity: i.count,
-                  hero: '${i.id} ${category.materials.indexOf(i)}',
-                  includeMargin: false,
-                  section: ItemSection.MATERIAL,
-                ))
-                .toList(),
+              children: items,
             ),
           ),
         ],

--- a/lib/features/bank/pages/material.dart
+++ b/lib/features/bank/pages/material.dart
@@ -9,7 +9,15 @@ import 'package:guildwars2_companion/features/bank/models/material_category.dart
 import 'package:guildwars2_companion/features/item/enums/item_section.dart';
 import 'package:guildwars2_companion/features/item/widgets/item_box.dart';
 
-class MaterialBankPage extends StatelessWidget {
+
+class MaterialBankPage extends StatefulWidget {
+  @override
+  _MaterialBankPageState createState() => _MaterialBankPageState();
+}
+
+class _MaterialBankPageState extends State<MaterialBankPage> {
+  String _search = "";
+
   @override
   Widget build(BuildContext context) {
     return CompanionAccent(
@@ -39,10 +47,26 @@ class MaterialBankPage extends StatelessWidget {
                   BlocProvider.of<BankBloc>(context).add(LoadBankEvent());
                   await Future.delayed(Duration(milliseconds: 200), () {});
                 },
-                child: CompanionListView(
-                  children: state.materialCategories
-                    .map((c) => _MaterialCategoryCard(category: c))
-                    .toList(),
+                child: Column(
+                  children: <Widget>[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
+                      child: TextFormField(
+                        decoration: InputDecoration(
+                          hintText: "Item to search for",
+                          labelText: "Search",
+                          contentPadding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                          focusColor: Theme.of(context).accentColor
+                        ),
+                        onChanged: (String value) {
+                          setState(() => _search = value );
+                        },
+                      ),
+                    ),
+                    Expanded(
+                      child: buildCategories(state, this._search)
+                    )
+                  ]
                 ),
               );
             }
@@ -55,12 +79,21 @@ class MaterialBankPage extends StatelessWidget {
       ),
     );
   }
+
+  CompanionListView buildCategories(LoadedBankState state, String search) {
+    return CompanionListView(
+      children: state.materialCategories
+        .map((c) => _MaterialCategoryCard(category: c, search: search))
+        .toList(),
+    );
+  }
 }
 
 class _MaterialCategoryCard extends StatelessWidget {
   final MaterialCategory category;
+  String search;
 
-  _MaterialCategoryCard({@required this.category});
+  _MaterialCategoryCard({@required this.category, @required this.search});
 
   @override
   Widget build(BuildContext context) {
@@ -83,6 +116,7 @@ class _MaterialCategoryCard extends StatelessWidget {
               spacing: 4.0,
               runSpacing: 4.0,
               children: category.materials
+                .where((i) => i.itemInfo.name.toLowerCase().contains(search.toLowerCase()))
                 .map((i) => ItemBox(
                   item: i.itemInfo,
                   quantity: i.count,


### PR DESCRIPTION
Adds a search bar to the Bank > Materials page, that updates the displayed items as the search is changed. Materials categories that are empty after the search filter are hidden.

## Related Issue
https://github.com/DanielScholte/GuildWars2Companion/issues/76

## How Has This Been Tested?
Manual testing on a Pixel 5 (see recording).

## Screen recording:
![material_search_25](https://user-images.githubusercontent.com/5042399/131239131-7c304892-4966-4b3e-88e4-fb9e05e7f8e4.gif)
