### PR TITLE
Fix event timers for Tyria Day/Night and Kaineng Blackout

### DIFF
--- a/assets/data/event_timers/meta_events.json
+++ b/assets/data/event_timers/meta_events.json
@@ -18,7 +18,7 @@
             {
                 "id": "day",
                 "name": "Day",
-                "durationInMinutes": 40
+                "durationInMinutes": 70
             },
             {
                 "id": "dusk",
@@ -510,10 +510,10 @@
             {
                 "id": "blackout",
                 "name": "Kaineng Blackout",
-                "durationInMinutes": 30
+                "durationInMinutes": 40
             },
             {
-                "durationInMinutes": 90
+                "durationInMinutes": 80
             }
         ]
     },


### PR DESCRIPTION
Fix event timers for Tyria Day/Night and Kaineng Blackout

## Description
I fixed the event timer for Tyria Day/Night and checked the other timers, Kaineng Blackout was off too.

## Related Issue
[Issue #83](https://github.com/DanielScholte/GuildWars2Companion/issues/83)
[Timer Tyria Day/Night](https://wiki.guildwars2.com/wiki/Day_and_night)
[Timer Kaineng Blackout](https://wiki.guildwars2.com/wiki/New_Kaineng_City)

## How Has This Been Tested?
I started the solution on a Pixel 2 emulator with API 29, no crash to report and the timers were ticking correctly